### PR TITLE
Fjern caching på SykmeldingService.hentSykmeldinger

### DIFF
--- a/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykmeldingService.java
+++ b/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykmeldingService.java
@@ -49,7 +49,6 @@ public class SykmeldingService {
         this.sykmeldingV1 = sykmeldingV1;
     }
 
-    @Cacheable(cacheNames = CACHENAME_SYKMELDING, key = "#fnr.concat(#oidcIssuer)", condition = "#fnr != null && #oidcIssuer != null")
     public List<Sykmelding> hentSykmeldinger(String fnr, List<WSSkjermes> skjermes, String oidcIssuer) {
         if (isBlank(fnr) || !fnr.matches("\\d{11}$")) {
             log.error("Prøvde å hente sykmeldinger med fnr");


### PR DESCRIPTION
For at ikke alle sykmeldinger som hentes skal være AG-versjon
Burde på sikt gjøres på en bedre måte f.eks. med bedre cache-nøkkel