### PR TITLE
Fjern caching på hentSykeforloep

### DIFF
--- a/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykeforloepService.java
+++ b/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykeforloepService.java
@@ -76,7 +76,6 @@ public class SykeforloepService {
         this.sykefravaersoppfoelgingV1 = sykefravaersoppfoelgingV1;
     }
 
-    @Cacheable(cacheNames = CACHENAME_SYFOSYKEFORLOP, key = "#fnr.concat(#oidcIssuer)", condition = "#fnr != null && #oidcIssuer != null")
     public List<Sykeforloep> hentSykeforloep(String fnr, String oidcIssuer) {
         if (isBlank(fnr) || !fnr.matches("\\d{11}$")) {
             log.error("Prøvde å hente sykeforløp med fnr og oidcIssuer {}");


### PR DESCRIPTION
Siden vi nå alltid henter nyeste sykmeldinger, burde vi også få siste versjon av sykeforløpet, som baserer seg på sykmeldinger