### PR TITLE
Fjern caching på hentSykeforloep

### DIFF
--- a/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykeforloepService.java
+++ b/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykeforloepService.java
@@ -3,9 +3,7 @@ package no.nav.sbl.dialogarena.modiasyforest.services;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.sbl.dialogarena.modiasyforest.config.SykmeldingerConfig;
 import no.nav.sbl.dialogarena.modiasyforest.mappers.SykmeldingMapper;
-import no.nav.sbl.dialogarena.modiasyforest.rest.domain.NaermesteLeder;
-import no.nav.sbl.dialogarena.modiasyforest.rest.domain.Oppfolgingstilfelle;
-import no.nav.sbl.dialogarena.modiasyforest.rest.domain.Sykeforloep;
+import no.nav.sbl.dialogarena.modiasyforest.rest.domain.*;
 import no.nav.sbl.dialogarena.modiasyforest.rest.domain.sykmelding.Sykmelding;
 import no.nav.sbl.dialogarena.modiasyforest.rest.domain.tidslinje.Hendelse;
 import no.nav.security.oidc.context.OIDCRequestContextHolder;
@@ -20,7 +18,6 @@ import no.nav.tjeneste.virksomhet.sykmelding.v1.informasjon.*;
 import no.nav.tjeneste.virksomhet.sykmelding.v1.meldinger.WSHentOppfoelgingstilfelleListeRequest;
 import no.nav.tjeneste.virksomhet.sykmelding.v1.meldinger.WSHentOppfoelgingstilfelleListeResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
@@ -38,7 +35,6 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.empty;
-import static no.nav.sbl.dialogarena.modiasyforest.config.CacheConfig.CACHENAME_SYFOSYKEFORLOP;
 import static no.nav.sbl.dialogarena.modiasyforest.rest.domain.tidslinje.Hendelsestype.valueOf;
 import static no.nav.sbl.dialogarena.modiasyforest.utils.OIDCUtil.tokenFraOIDC;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -76,7 +72,6 @@ public class SykeforloepService {
         this.sykefravaersoppfoelgingV1 = sykefravaersoppfoelgingV1;
     }
 
-    @Cacheable(cacheNames = CACHENAME_SYFOSYKEFORLOP, key = "#fnr.concat(#oidcIssuer)", condition = "#fnr != null && #oidcIssuer != null")
     public List<Sykeforloep> hentSykeforloep(String fnr, String oidcIssuer) {
         if (isBlank(fnr) || !fnr.matches("\\d{11}$")) {
             log.error("Prøvde å hente sykeforløp med fnr og oidcIssuer {}");

--- a/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykmeldingService.java
+++ b/src/main/java/no/nav/sbl/dialogarena/modiasyforest/services/SykmeldingService.java
@@ -11,7 +11,6 @@ import no.nav.tjeneste.virksomhet.sykmelding.v1.informasjon.WSSkjermes;
 import no.nav.tjeneste.virksomhet.sykmelding.v1.meldinger.WSHentSykmeldingListeRequest;
 import no.nav.tjeneste.virksomhet.sykmelding.v1.meldinger.WSHentSykmeldingListeResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
@@ -20,7 +19,6 @@ import javax.ws.rs.NotFoundException;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static no.nav.sbl.dialogarena.modiasyforest.config.CacheConfig.CACHENAME_SYKMELDING;
 import static no.nav.sbl.dialogarena.modiasyforest.mappers.SykmeldingMapper.sykmeldinger;
 import static no.nav.sbl.dialogarena.modiasyforest.utils.OIDCUtil.tokenFraOIDC;
 import static org.apache.commons.lang3.StringUtils.isBlank;


### PR DESCRIPTION
Siden vi nå alltid henter nyeste sykmeldinger, burde vi også få siste versjon av sykeforløpet, som baserer seg på sykmeldinger

Fjern ubrukte imports også fra sykmeldingService, da dette ikke ble gjort ved fjerning av cache derfra.