### PR TITLE
Increase timeToIdleSeconds for caches

### DIFF
--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ehcache>
     <defaultCache eternal="true" maxElementsInMemory="1000" overflowToDisk="false"/>
-    <cache name="aktoerid" maxElementsInMemory="10000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="aktoerfnr" maxElementsInMemory="10000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="arbeidsforhold" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="diskresjonskode" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="dkiffnr" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="egenansatt" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="organisasjonnavn" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="syfofinnledere" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="syfoledere" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="sykepengesoknad" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
-    <cache name="tpsbruker" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="300"/>
+    <cache name="aktoerid" maxElementsInMemory="10000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="aktoerfnr" maxElementsInMemory="10000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="arbeidsforhold" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="diskresjonskode" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="dkiffnr" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="egenansatt" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="organisasjonnavn" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="syfofinnledere" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="syfoledere" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="sykepengesoknad" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
+    <cache name="tpsbruker" maxElementsInMemory="5000" overflowToDisk="false" eternal="false" timeToLiveSeconds="3600" timeToIdleSeconds="600"/>
 </ehcache>


### PR DESCRIPTION
Jeg tenker at 5min for timeToIdleSeconds for Modiasyforest som standard for for lavt, så dobler denne til 10min.